### PR TITLE
Add repo_dir and repo_pre_run_scripts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,10 @@
 name: 'amplify-cli-action'
 description: 'This action builds and deploys your AWS Amplify project'
 inputs:
-  project_dir: 
+  project_dir:
     description: 'the root project directory: use it if you amplify project is not this repo root directory'
     required: false
-  source_dir: 
+  source_dir:
     description: 'front-end source location where aws_exports.js will be generated'
     required: false
     default: 'src'
@@ -12,7 +12,7 @@ inputs:
     description: 'front-end artifacts deployment directory that gets uploaded to S3 during amplify publish'
     required: false
     default: 'dist'
-  build_command: 
+  build_command:
     description: 'a build command to run with amplify publish (to build front-end deployment artifacts)'
     required: false
     default: 'npm run build'
@@ -33,6 +33,13 @@ inputs:
     description: 'additional arguments to pass to ampify_command defined command'
     required: false
     default: ''
+  repo_dir:
+    description: 'the root project directory. Can be used in case of monorepos'
+    required: false
+    default: '.'
+  repo_pre_run_scripts:
+    description: 'Scripts to be run on repo_dir before amplify actions'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -46,6 +53,8 @@ runs:
     - ${{ inputs.delete_lock }}
     - ${{ inputs.amplify_cli_version }}
     - ${{ inputs.amplify_arguments }}
+    - ${{ inputs.repo_dir }}
+    - ${{ inputs.repo_pre_run_scripts }}
 branding:
   icon: 'git-commit'
   color: 'orange'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,19 +22,15 @@ if [ -z "$6" ] ; then
   exit 1
 fi
 
+# cd to repo_dir if specified
+if [ -n "${10}" ] ; then
+  cd "${10}"
+fi
 
-# TODO Refactor this
-case $5 in
-  push)
-    yarn --frozen-lockfile
-    yarn build:package @hitz-group/online-store
-    ;;
-
-  publish)
-    yarn --frozen-lockfile
-    yarn build:package @hitz-group/online-store
-    ;;
-esac
+# run repo scripts if specified
+if [ -n "${11}" ] ; then
+  eval ${11}
+fi
 
 # cd to project_dir if custom subfolder is specified
 if [ -n "$1" ] ; then


### PR DESCRIPTION
Add repo_dir and repo_pre_run_scripts

- repo_dir:
  - description: 'the root project directory. Can be used in case of monorepos'
  - required: false
  - default: '.'
- repo_pre_run_scripts:
  - description: 'Scripts to be run on repo_dir before amplify actions'
  - required: false 


-----
Usage
```
repo_pre_run_scripts: 'yarn --frozen-lockfile; yarn build:package @hitz-group/online-store'
```